### PR TITLE
Support multiple To address when importing rfc822

### DIFF
--- a/emails/loader/local_store.py
+++ b/emails/loader/local_store.py
@@ -388,7 +388,8 @@ class MsgLoader(BaseLoader):
         elif name == 'to':
             r = self.decode_address_header_value(value)
             if r:
-                message.mail_to = r[0]
+                message.mail_to = r
+
         elif name == 'from':
             r = self.decode_address_header_value(value)
             if r:

--- a/emails/testsuite/loader/test_rfc822_loader.py
+++ b/emails/testsuite/loader/test_rfc822_loader.py
@@ -43,7 +43,7 @@ def test_msgloader():
     data = {'charset': 'utf-8',
             'subject': 'Что-то по-русски',
             'mail_from': ('Максим Иванов', 'ivanov@ya.ru'),
-            'mail_to': ('Полина Сергеева', 'polina@mail.ru'),
+            'mail_to': [('Полина Сергеева', 'polina@mail.ru'),('test', 'test@example.com')],
             'html': '<h1>Привет!</h1><p>В первых строках...',
             'text': 'Привет!\nВ первых строках...',
             'headers': {'X-Mailer': 'python-emails',
@@ -67,6 +67,7 @@ def test_msgloader():
     map_cid = "cid:%s" % source_message.attachments['Map.png'].content_id
     assert loader.content(map_cid) == 'Y'
 
+    assert message.mail_to == data['mail_to']
     assert message.subject == data['subject']
     print(message._headers)
     assert message._headers['sender'] == '웃'


### PR DESCRIPTION
When importing an rfc822 email, the previous behaviour was
to only respect the first entry.  If multiple To addresses
are specified then these are ignored.

This change forces all entries to be added to mail_to field
with an associated change to the test.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>