### PR TITLE
Support CC/BCC importing on rfc822

### DIFF
--- a/emails/loader/local_store.py
+++ b/emails/loader/local_store.py
@@ -390,6 +390,16 @@ class MsgLoader(BaseLoader):
             if r:
                 message.mail_to = r
 
+        elif name == 'cc':
+            r = self.decode_address_header_value(value)
+            if r:
+                message.cc = r
+
+        elif name == 'bcc':
+             r = self.decode_address_header_value(value)
+             if r:
+               message.bcc = r
+
         elif name == 'from':
             r = self.decode_address_header_value(value)
             if r:

--- a/emails/message.py
+++ b/emails/message.py
@@ -260,6 +260,9 @@ class MessageBuildMixin(object):
         if self.cc:
             self.set_header(msg, 'Cc', ", ".join([self.encode_address_header(addr) for addr in self.cc]), encode=False)
 
+        if self.bcc:
+            self.set_header(msg, 'Bcc', ", ".join([self.encode_address_header(addr) for addr in self.bcc]), encode=False)
+
         return msg
 
     def _build_html_part(self):

--- a/emails/testsuite/loader/test_rfc822_loader.py
+++ b/emails/testsuite/loader/test_rfc822_loader.py
@@ -43,7 +43,9 @@ def test_msgloader():
     data = {'charset': 'utf-8',
             'subject': 'Что-то по-русски',
             'mail_from': ('Максим Иванов', 'ivanov@ya.ru'),
-            'mail_to': [('Полина Сергеева', 'polina@mail.ru'),('test', 'test@example.com')],
+            'mail_to': [('Полина Сергеева', 'polina@mail.ru'), ('test', 'test@example.com')],
+            'cc': [('CC User', 'cc@example.com'), ('cc', 'cc.1@example.com')],
+            'bcc': [('BCC User', 'bcc@example.com')],
             'html': '<h1>Привет!</h1><p>В первых строках...',
             'text': 'Привет!\nВ первых строках...',
             'headers': {'X-Mailer': 'python-emails',
@@ -68,6 +70,8 @@ def test_msgloader():
     assert loader.content(map_cid) == 'Y'
 
     assert message.mail_to == data['mail_to']
+    assert message.cc == data['cc']
+    assert message.bcc == data['bcc']
     assert message.subject == data['subject']
     print(message._headers)
     assert message._headers['sender'] == '웃'


### PR DESCRIPTION
Previously only To was supported on rfc822 importing and
Cc/Bcc was silently dropped.

This change adds support (and related test) for these two
fields.

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>