### PR TITLE
Fix HTML5 links garbled by lxml

### DIFF
--- a/emails/testsuite/loader/test_loaders.py
+++ b/emails/testsuite/loader/test_loaders.py
@@ -25,8 +25,7 @@ OLDORNAMENT_URLS = dict(from_url='campaignmonitor-samples/oldornament/index.html
 
 def test__from_html():
 
-    with pytest.raises(XMLSyntaxError):
-        emails.loader.from_html(html='')
+    emails.loader.from_html(html='')
 
     assert '-X-' in emails.loader.from_html(html='-X-').html
 

--- a/emails/transformer.py
+++ b/emails/transformer.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 from __future__ import unicode_literals
+import html5lib
 import logging
 import posixpath
 import re
@@ -82,10 +83,13 @@ class HTMLParser(object):
     @property
     def tree(self):
         if self._tree is None:
-            parser = self._method == 'xml' \
-                         and etree.XMLParser(ns_clean=False, resolve_entities=False) \
-                         or etree.HTMLParser()
-            self._tree = etree.fromstring(self._html.strip(), parser)
+            html_data = self._html.strip()
+            if self._method == 'xml':
+                parser = etree.XMLParser(ns_clean=False, resolve_entities=False)
+                self._tree = etree.fromstring(html_data, parser)
+            else:
+                parsed = html5lib.parse(html_data, treebuilder='lxml', namespaceHTMLElements=False)
+                self._tree = parsed.getroot()
         return self._tree
 
     def to_string(self, encoding='utf-8', **kwargs):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,4 @@ chardet
 python-dateutil
 requests
 premailer>=2.8.3
+html5lib


### PR DESCRIPTION
Fix following issue
```
>>> etree.tostring(etree.fromstring('<a><table></table></a>', parser=etree.HTMLParser()))
'<html><body><a/><table/></body></html>'
```