### PR TITLE
Add html5 parser method, based on html5lib

### DIFF
--- a/emails/testsuite/smtp_servers.py
+++ b/emails/testsuite/smtp_servers.py
@@ -9,7 +9,7 @@ SERVERS = {
     'gmail.com-tls': dict(from_email=_from, to_email='s.lavrinenko@gmail.com',
                           host='alt1.gmail-smtp-in.l.google.com', port=25, tls=True),
 
-    'mx.yandex.ru': dict(from_email=_from, to_email='drlavr@yandex.ru',
+    'mx.yandex.ru': dict(from_email=_from, to_email='python.emails.test@yandex.ru',
                          host='mx.yandex.ru', port=25),
 
     #'mailtrap.io': dict(from_email=_from, port=25, **_mailtrap),

--- a/emails/testsuite/transformer/test_parser.py
+++ b/emails/testsuite/transformer/test_parser.py
@@ -6,8 +6,8 @@ from emails.transformer import HTMLParser
 def test_parser_inputs():
 
     def _cleaned_body(s):
-        for el in ('html', 'body'):
-            s = s.replace('<%s>' % el, '').replace('</%s>' % el, '')
+        for el in ('html', 'body', 'head'):
+            s = s.replace('<%s>' % el, '').replace('</%s>' % el, '').replace('<%s/>' % el, '')
         return s
 
     # This is a fixation of de-facto rendering results
@@ -17,9 +17,11 @@ def test_parser_inputs():
             ("<a href='[]&'>_</a>", '<a href="[]&amp;">_</a>'),
             ('<p>a\r\n', '<p>a</p>')
     ):
-        r = HTMLParser(html=html).to_string()
-        print("html=", html.__repr__(), "result=", r.__repr__(), sep='')
-        assert _cleaned_body(r) == result
+        for parser in [HTMLParser(html=html, method='html'),
+                       HTMLParser(html=html, method='html5')]:
+            r = parser.to_string()
+            print("html=", html.__repr__(), "result=", r.__repr__(), sep='')
+            assert _cleaned_body(r) == result
 
 
 def test_breaking_title():

--- a/emails/testsuite/transformer/test_transformer.py
+++ b/emails/testsuite/transformer/test_transformer.py
@@ -29,8 +29,13 @@ def test_image_apply():
         assert after in t.to_string()
 
 
+def test_html5_transform():
+    assert Transformer(html="<a><table/></a>", method="html").to_string() == '<html><body><a/><table/></body></html>'
+    assert Transformer(html="<a><table/></a>", method="html5").to_string() == '<html><head/><body><a><table/></a></body></html>'
+
+
 def test_entity_13():
-    assert Transformer(html="<div>x\r\n</div>").to_string() == '<html><body><div>x\n</div></body></html>'
+    assert "<div>x\n</div>" in Transformer(html="<div>x\r\n</div>").to_string()
 
 
 def test_link_apply():

--- a/requirements/tests-base.txt
+++ b/requirements/tests-base.txt
@@ -3,3 +3,4 @@ mako
 speaklater
 pytest
 pytest-cov
+html5lib


### PR DESCRIPTION
We had troubles with html5 letters, .i.e.:

    >>> Transformer(html="<a><table/></a>", method="html").to_string()
    '<html><body><a/><table/></body></html>'
 
To solve this problem we added method "html5", based on html5lib:

    >>> Transformer(html="<a><table/></a>", method="html5").to_string()
    '<html><head/><body><a><table/></a></body></html>'
