### PR TITLE
Encode address names only when it's not ascii

### DIFF
--- a/emails/testsuite/message/test_message.py
+++ b/emails/testsuite/message/test_message.py
@@ -113,6 +113,23 @@ def test_headers_not_double_encoded():
     assert decode_header(msg['Subject']) == TEXT
 
 
+def test_headers_encode_when_needed():
+
+    for text, encoded in (
+        ('웃', '=?utf-8?b?7JuD?='),
+        ('human stick figure', 'human stick figure'),
+    ):
+        m = Message()
+        m.mail_from = (text, 'a@b.c')
+        m.mail_to = (text, 'a@b.c')
+        m.subject = text
+        m.html = '...'
+        msg = m.as_message()
+        assert parseaddr(msg['From'])[0] == encoded
+        assert parseaddr(msg['To'])[0] == encoded
+        # assert msg['Subject'] == encoded  # subject encodes later
+
+
 def test_message_addresses():
 
     m = Message()

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -170,16 +170,16 @@ def sanitize_email(addr, encoding='ascii', parse=False):
     return addr
 
 
-def sanitize_address(addr, encoding='ascii'):
+def sanitize_address(addr, encoding='utf-8'):
     if isinstance(addr, string_types):
         addr = parseaddr(to_unicode(addr))
     nm, addr = addr
     # This try-except clause is needed on Python 3 < 3.2.4
     # http://bugs.python.org/issue14291
     try:
-        nm = Header(nm, encoding).encode()
+        nm = Header(nm, 'ascii').encode()
     except UnicodeEncodeError:
-        nm = Header(nm, 'utf-8').encode()
+        nm = Header(nm, encoding).encode()
     return formataddr((nm, sanitize_email(addr, encoding=encoding, parse=False)))
 
 

--- a/requirements/tests-2.6.txt
+++ b/requirements/tests-2.6.txt
@@ -3,3 +3,5 @@
 
 django==1.6
 ordereddict
+pytest==3.2  # since pytest 3.3 dropped python 2.6 and 3.3 support
+pytest-cov==2.5  # since 2.6 dropped support for pytest<3.5

--- a/requirements/tests-3.3.txt
+++ b/requirements/tests-3.3.txt
@@ -2,3 +2,5 @@
 --requirement=tests-base.txt
 
 django<1.9
+pytest==3.2  # since pytest 3.3 dropped python 2.6 and 3.3 support
+pytest-cov==2.5  # since 2.6 dropped support for pytest<3.5

--- a/requirements/tests-base.txt
+++ b/requirements/tests-base.txt
@@ -1,7 +1,7 @@
 jinja2
 mako
 speaklater
-pytest==3.2  # since pytest 3.3 dropped python 2.6 and 3.3 support
-pytest-cov==2.5  # since 2.6 dropped support for pytest<3.5
+pytest>=3
+pytest-cov
 html5lib
 six

--- a/requirements/tests-base.txt
+++ b/requirements/tests-base.txt
@@ -1,7 +1,7 @@
 jinja2
 mako
 speaklater
-pytest
-pytest-cov
+pytest==3.2  # since pytest 3.3 dropped python 2.6 and 3.3 support
+pytest-cov==2.5  # since 2.6 dropped support for pytest<3.5
 html5lib
 six

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [wheel]
 universal=1
 
-[pytest]
+[tool:pytest]
 norecursedirs = .* {arch} *.egg *.egg-info dist build requirements


### PR DESCRIPTION
To, From fields are encoded always, not only when it's not ascii.
This merge request fixes it.