### PR TITLE
Avoid DeprecationWarning by importing from collections.abc first

### DIFF
--- a/emails/compat/orderedset.py
+++ b/emails/compat/orderedset.py
@@ -2,7 +2,11 @@
 from __future__ import unicode_literals
 __all__ = ['OrderedSet', ]
 
-from collections import MutableSet
+try:
+    from collections.abc import MutableSet
+except ImportError:
+    from collections import MutableSet
+
 
 # http://code.activestate.com/recipes/576694/
 


### PR DESCRIPTION
Noticed some deprecation warnings in our code which was using python-emails so fixing it.. also an existing issue is referring to the same: https://github.com/lavr/python-emails/issues/119.