### PR TITLE
Fix UnicodeEncodeError caused by non encoded msg body.

### DIFF
--- a/emails/backend/smtp/backend.py
+++ b/emails/backend/smtp/backend.py
@@ -114,7 +114,7 @@ class SMTPBackend(object):
 
         response = send(from_addr=from_addr,
                         to_addrs=to_addrs,
-                        msg=msg.as_string(),
+                        msg=msg.as_string().encode(msg.charset),
                         mail_options=mail_options,
                         rcpt_options=rcpt_options)
 


### PR DESCRIPTION
Hi,

Thank for this awesome project @lavr !

I propose this PR in order to fix an unexpected issue. All characters outside of the ASCII range (in body msg) is going to trigger a exception.

```
  File "/home/x/.local/lib/python3.7/site-packages/emails-0.5.15-py3.7.egg/emails/backend/smtp/backend.py", line 80, in wrapper
    return func(*args, **kwargs)
  File "/home/x/.local/lib/python3.7/site-packages/emails-0.5.15-py3.7.egg/emails/backend/smtp/backend.py", line 103, in _send
    return client.sendmail(**kwargs)
  File "/home/x/.local/lib/python3.7/site-packages/emails-0.5.15-py3.7.egg/emails/backend/smtp/client.py", line 105, in sendmail
    (code, resp) = self.data(msg)
  File "/usr/x/lib/python3.7/smtplib.py", line 563, in data
    msg = _fix_eols(msg).encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 1163: ordinal not in range(128)
```

This change will encode body in specified charset (in object Message).


