### PR TITLE
Quit SMTP connection on failed login

### DIFF
--- a/emails/backend/smtp/client.py
+++ b/emails/backend/smtp/client.py
@@ -25,7 +25,11 @@ class SMTPClientWithResponse(SMTP):
 
         SMTP.__init__(self, **kwargs)
 
-        self.initialize()
+        try:
+            self.initialize()
+        except smtplib.SMTPAuthenticationError:
+            self.quit()
+            raise
 
 
     def initialize(self):


### PR DESCRIPTION
This is a slight improvement to the SMTPClient. Currently the client does not gracefully quit the connection when authentication fails. While the socket is eventually closed on GC, this could be done earlier by explicitly quitting.