### PR TITLE
Fix incorrect isinstance check in parse_name_and_email_list

### DIFF
--- a/emails/utils.py
+++ b/emails/utils.py
@@ -131,7 +131,7 @@ def parse_name_and_email_list(elements, encoding='utf-8'):
         # Let's do some guesses
         if isinstance(elements, tuple):
             n, e = elements
-            if isinstance(e, string_types) and (not n or isinstance(e, string_types)):
+            if isinstance(e, string_types) and (not n or isinstance(n, string_types)):
                 # It is probably a pair (name, email)
                 return [parse_name_and_email(elements, encoding), ]
 


### PR DESCRIPTION
## Summary
- Fix typo on line 134 of `emails/utils.py`: `isinstance(e, string_types)` was checked twice instead of checking `n` in the second test, causing the name type validation to be silently skipped.

Fixes #167