### PR TITLE
Catch all exceptions during SMTP client initialization

### DIFF
--- a/emails/backend/smtp/client.py
+++ b/emails/backend/smtp/client.py
@@ -27,7 +27,7 @@ class SMTPClientWithResponse(SMTP):
 
         try:
             self.initialize()
-        except smtplib.SMTPAuthenticationError:
+        except Exception:
             self.quit()
             raise
 


### PR DESCRIPTION
## Summary
- Broaden the `except` clause in `SMTPClientWithResponse.__init__` from `SMTPAuthenticationError` to `Exception`, so the connection is cleaned up when `starttls()` or `ehlo_or_helo_if_needed()` fails as well.

Fixes #179