### PR TITLE
Make HTML transformation dependencies optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ and more:
 * DKIM signature
 * Render body from template
 * Flask extension and Django integration
-* Message body transformation methods
+* HTML transformation with CSS inlining (``pip install emails[html]``)
 * Load message from url or from file
 
 |

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,3 +7,11 @@ Install from pypi:
 .. code-block:: bash
 
     $ pip install emails
+
+This installs the lightweight core for building and sending email messages.
+
+To use HTML transformation features (CSS inlining, image embedding, loading from URL/file):
+
+.. code-block:: bash
+
+    $ pip install emails[html]

--- a/emails/utils.py
+++ b/emails/utils.py
@@ -15,8 +15,6 @@ from email.mime.multipart import MIMEMultipart
 from email.header import Header, decode_header as decode_header_
 from email.utils import parseaddr, formatdate, escapesre, specialsre
 
-import requests
-
 from . import USER_AGENT
 from .exc import HTTPLoaderError
 
@@ -270,6 +268,7 @@ DEFAULT_REQUESTS_PARAMS = dict(allow_redirects=True,
 
 
 def fetch_url(url, valid_http_codes=(200, ), requests_args=None):
+    import requests
     args = {}
     args.update(DEFAULT_REQUESTS_PARAMS)
     args.update(requests_args or {})

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,10 @@ settings.update(
               'emails.packages.dkim'
              ],
     scripts=['scripts/make_rfc822.py'],
-    install_requires=['cssutils', 'lxml', 'chardet', 'python-dateutil', 'requests', 'premailer'],
+    install_requires=['python-dateutil'],
+    extras_require={
+        'html': ['cssutils', 'lxml', 'chardet', 'requests', 'premailer'],
+    },
     zip_safe=False,
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
## Summary
- Move heavy dependencies (lxml, cssutils, premailer, chardet, requests) from `install_requires` to `extras_require['html']`
- Make `requests` import lazy in `utils.py` so `import emails` works without it
- Base install (`pip install emails`) only requires `python-dateutil`
- Full install: `pip install emails[html]`
- Document the optional install in README and docs/install.rst

Supersedes #189.
