### PR TITLE
Add reply_to parameter to Message

### DIFF
--- a/emails/message.py
+++ b/emails/message.py
@@ -48,7 +48,8 @@ class BaseMessage:
                  attachments: list[dict[str, Any] | BaseFile] | None = None,
                  cc: _AddressList = None,
                  bcc: _AddressList = None,
-                 headers_encoding: str | None = None) -> None:
+                 headers_encoding: str | None = None,
+                 reply_to: _AddressList = None) -> None:
 
         self._attachments: MemoryFileStore | None = None
         self.charset: str = charset or 'utf-8'
@@ -60,6 +61,7 @@ class BaseMessage:
         self.set_mail_to(mail_to)
         self.set_cc(cc)
         self.set_bcc(bcc)
+        self.set_reply_to(reply_to)
         self.set_headers(headers)
         self.set_html(html=html)
         self.set_text(text=text)
@@ -102,6 +104,14 @@ class BaseMessage:
         return self._bcc
 
     bcc = property(get_bcc, set_bcc)
+
+    def set_reply_to(self, addr: _AddressList) -> None:
+        self._reply_to = parse_name_and_email_list(addr)
+
+    def get_reply_to(self) -> list[tuple[str | None, str | None]]:
+        return self._reply_to
+
+    reply_to = property(get_reply_to, set_reply_to)
 
     def get_recipients_emails(self) -> list[str | None]:
         """
@@ -270,6 +280,9 @@ class MessageBuildMixin:
 
         if self.cc:
             self.set_header(msg, 'Cc', ", ".join([self.encode_address_header(addr) for addr in self.cc]), encode=False)
+
+        if self.reply_to:
+            self.set_header(msg, 'Reply-To', ", ".join([self.encode_address_header(addr) for addr in self.reply_to]), encode=False)
 
         return msg
 

--- a/emails/testsuite/message/test_message.py
+++ b/emails/testsuite/message/test_message.py
@@ -194,6 +194,33 @@ def test_message_id():
     assert m.as_message()['Message-ID'] == 'XXX'
 
 
+def test_reply_to():
+
+    params = dict(html='...', mail_from='a@b.c', mail_to='to@x.z')
+
+    # Single address
+    m = Message(reply_to='reply@x.z', **params)
+    assert m.as_message()['Reply-To'] == 'reply@x.z'
+
+    # Tuple (name, email)
+    m = Message(reply_to=('Марья', 'maria@example.net'), **params)
+    assert 'maria@example.net' in m.as_message()['Reply-To']
+
+    # Multiple addresses
+    m = Message(reply_to=['a@x.z', 'b@x.z'], **params)
+    assert 'a@x.z' in m.as_message()['Reply-To']
+    assert 'b@x.z' in m.as_message()['Reply-To']
+
+    # No reply-to by default
+    m = Message(**params)
+    assert m.as_message()['Reply-To'] is None
+
+    # Setter
+    m = Message(**params)
+    m.reply_to = 'reply@x.z'
+    assert m.as_message()['Reply-To'] == 'reply@x.z'
+
+
 def test_several_recipients():
 
     # Test multiple recipients in "To" header


### PR DESCRIPTION
## Summary

- Add `reply_to` parameter to `Message` constructor, consistent with `cc` and `bcc`
- Support single address, `(name, email)` tuple, or list of addresses
- Add `reply_to` property with getter/setter
- Add tests

Closes #115