### PR TITLE
Skip data URIs in transformer

### DIFF
--- a/emails/testsuite/transformer/test_transformer.py
+++ b/emails/testsuite/transformer/test_transformer.py
@@ -85,6 +85,12 @@ def test_data_uri_preserved():
     m = emails.loader.from_string(html=html)
     assert len(m.attachments.keys()) == 0
 
+    # mixed-case scheme should also be preserved
+    mixed = DATA_URI.replace('data:', 'Data:')
+    html = '<img src="%s"/>' % mixed
+    m = emails.loader.from_string(html=html)
+    assert len(m.attachments.keys()) == 0
+
 
 ROOT = os.path.dirname(__file__)
 

--- a/emails/testsuite/transformer/test_transformer.py
+++ b/emails/testsuite/transformer/test_transformer.py
@@ -66,6 +66,26 @@ def test_tag_attribute():
     assert m3.attachments['1.jpg'].content_disposition == "inline"
 
 
+def test_data_uri_preserved():
+    DATA_URI = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+    # data URIs in img src should be left untouched
+    html = '<img src="%s"/>' % DATA_URI
+    m = emails.loader.from_string(html=html)
+    assert len(m.attachments.keys()) == 0
+    assert DATA_URI in m.html
+
+    # data URIs in css url() should be left untouched
+    html = '<div style="background: url(%s);">x</div>' % DATA_URI
+    m = emails.loader.from_string(html=html)
+    assert len(m.attachments.keys()) == 0
+
+    # data URIs in background attribute should be left untouched
+    html = '<table background="%s"/>' % DATA_URI
+    m = emails.loader.from_string(html=html)
+    assert len(m.attachments.keys()) == 0
+
+
 ROOT = os.path.dirname(__file__)
 
 def test_local_premailer():

--- a/emails/transformer.py
+++ b/emails/transformer.py
@@ -242,6 +242,9 @@ class BaseTransformer(HTMLParser):
         # Return local uri
         #
 
+        if uri.startswith('data:'):
+            return uri
+
         if callback is None:
             # Default callback: skip images with data-emails="ignore" attribute
             callback = lambda _, hints: hints['attrib'] != 'ignore'

--- a/emails/transformer.py
+++ b/emails/transformer.py
@@ -242,7 +242,7 @@ class BaseTransformer(HTMLParser):
         # Return local uri
         #
 
-        if uri.startswith('data:'):
+        if uri[:5].lower() == 'data:':
             return uri
 
         if callback is None:


### PR DESCRIPTION
## Summary

- Data URIs (`data:image/png;base64,...`) in HTML were treated as relative paths by the transformer, causing broken attachments and fetch errors
- Added early return in `_load_attachment_func` to preserve data URIs as-is
- Added tests for img src, css url(), and background attribute

Closes #62

## Test plan

- [x] All 86 tests pass
- [x] New test covers img src, css url(), and background with data URIs