### PR TITLE
Add Django CI jobs for DjangoMessage tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,7 +34,32 @@ jobs:
           python -m pip install -U pip
       - run: pip install tox
       - name: run tests
-        run: tox -e ${{ matrix.tox }} -- -m "not e2e"
+        run: tox -e ${{ matrix.tox }} -- -m "not e2e and not django"
+
+  django:
+    name: "django / ${{ matrix.django }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - {django: '4.2', tox: django42}
+          - {django: '5.2', tox: django52}
+          - {django: '6.0', tox: django60}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: update pip
+        run: |
+          pip install -U wheel
+          pip install -U setuptools
+          python -m pip install -U pip
+      - run: pip install tox
+      - name: run django tests
+        run: tox -e ${{ matrix.tox }}
 
   typecheck:
     name: "typecheck"

--- a/emails/testsuite/django_/test_django_integrations.py
+++ b/emails/testsuite/django_/test_django_integrations.py
@@ -1,7 +1,12 @@
 import warnings
+import pytest
 import emails
 import emails.message
+
+django = pytest.importorskip("django")
 from emails.django import DjangoMessage
+
+pytestmark = pytest.mark.django
 
 
 def test_django_message_proxy(django_email_backend):

--- a/requirements/tests-django.txt
+++ b/requirements/tests-django.txt
@@ -1,0 +1,2 @@
+--requirement=base.txt
+--requirement=tests-base.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ ignore_errors = true
 norecursedirs = .* {arch} *.egg *.egg-info dist build requirements
 markers =
     e2e: tests that require a running SMTP server
+    django: tests that require Django
 
 [coverage:run]
 omit = emails/testsuite/*

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,27 @@ deps =
     -rrequirements/tests.txt
 
 
+[testenv:django42]
+basepython = python3.12
+deps =
+    -rrequirements/tests-django.txt
+    Django>=4.2,<4.3
+commands = py.test -m django {posargs}
+
+[testenv:django52]
+basepython = python3.12
+deps =
+    -rrequirements/tests-django.txt
+    Django>=5.2,<5.3
+commands = py.test -m django {posargs}
+
+[testenv:django60]
+basepython = python3.12
+deps =
+    -rrequirements/tests-django.txt
+    Django>=6.0,<6.1
+commands = py.test -m django {posargs}
+
 [testenv:typecheck]
 deps = mypy
 commands = mypy emails/

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py310, py311, py312, py313, py314, pypy, style
 
 [testenv]
 passenv = TEST_*,SMTP_TEST_*
-commands = py.test --cov-report term --cov-report html --cov emails {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails --cov-config=setup.cfg {posargs}
 
 [testenv:pypy]
 deps =
@@ -35,21 +35,21 @@ basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=4.2,<4.3
-commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails --cov-config=setup.cfg -m django {posargs}
 
 [testenv:django52]
 basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=5.2,<5.3
-commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails --cov-config=setup.cfg -m django {posargs}
 
 [testenv:django60]
 basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=6.0,<6.1
-commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails --cov-config=setup.cfg -m django {posargs}
 
 [testenv:typecheck]
 deps = mypy

--- a/tox.ini
+++ b/tox.ini
@@ -35,21 +35,21 @@ basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=4.2,<4.3
-commands = py.test -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
 
 [testenv:django52]
 basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=5.2,<5.3
-commands = py.test -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
 
 [testenv:django60]
 basepython = python3.12
 deps =
     -rrequirements/tests-django.txt
     Django>=6.0,<6.1
-commands = py.test -m django {posargs}
+commands = py.test --cov-report term --cov-report html --cov emails -m django {posargs}
 
 [testenv:typecheck]
 deps = mypy


### PR DESCRIPTION
## Summary

- Add `pytest.mark.django` marker to Django integration tests
- Use `pytest.importorskip("django")` to prevent collection errors when Django is not installed
- Add 3 dedicated CI jobs testing against Django 4.2, 5.2, and 6.0 (Python 3.12)
- Add tox envs `django42`, `django52`, `django60` with pinned versions
- Exclude Django tests from regular unit jobs via `-m "not e2e and not django"`

Closes #201

## Test plan

- [ ] `django / 4.2` CI job passes
- [ ] `django / 5.2` CI job passes
- [ ] `django / 6.0` CI job passes
- [ ] Existing unit/e2e/typecheck jobs unaffected