### PR TITLE
Add jinja2 as optional dependency 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,3 +15,9 @@ To use HTML transformation features (CSS inlining, image embedding, loading from
 .. code-block:: bash
 
     $ pip install emails[html]
+
+To use Jinja2 templates (the ``T()`` shortcut):
+
+.. code-block:: bash
+
+    $ pip install emails[jinja]

--- a/emails/template/jinja_template.py
+++ b/emails/template/jinja_template.py
@@ -16,7 +16,13 @@ class JinjaTemplate(BaseTemplate):
             self.environment = environment
         else:
             if 'jinja2' not in globals():
-                globals()['jinja2'] = __import__('jinja2')
+                try:
+                    globals()['jinja2'] = __import__('jinja2')
+                except ImportError:
+                    raise ImportError(
+                        "jinja2 is required for template support. "
+                        "Install it with: pip install emails[jinja]"
+                    )
             self.environment = jinja2.Environment(**self.DEFAULT_JINJA_ENVIRONMENT)
 
     def compile_template(self):

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ settings.update(
     install_requires=['python-dateutil', 'puremagic', 'dkimpy'],
     extras_require={
         'html': ['cssutils', 'lxml', 'chardet', 'requests', 'premailer'],
+        'jinja': ['jinja2'],
     },
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
- Add 'jinja' extra to setup.py so users can `pip install emails[jinja]`
- Improve ImportError message when jinja2 is not installed
- Document jinja extra in install.rst

Closes #161