### PR TITLE
Serialize Message.as_bytes() with CRLF line endings so SMTP delivery sends RFC 5321-compliant DATA payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Jinja2 is now an optional dependency — install with `pip install emails[jinja2]` (#207, #161)
+- `Message.as_bytes()` now serializes messages with CRLF line endings for RFC 5321-compliant SMTP delivery (#213)
 
 ## 1.0
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -156,7 +156,8 @@ Message Methods
 
 .. method:: Message.as_bytes(message_cls=None)
 
-   Return the message as bytes, including DKIM signature if configured.
+   Return the message as bytes with CRLF line endings, including DKIM
+   signature if configured.
 
    :param message_cls: Optional custom MIME message class.
    :returns: Message as bytes.

--- a/emails/message.py
+++ b/emails/message.py
@@ -19,6 +19,8 @@ from .signers import DKIMSigner
 
 load_email_charsets()  # sic!
 
+RFC5321_LINESEP = '\r\n'
+
 
 # Type alias for email addresses accepted by the public API
 _Address = str | tuple[str | None, str] | None
@@ -366,7 +368,7 @@ class MessageBuildMixin:
         """
         Returns message as bytes.
         """
-        r = self.build_message(message_cls=message_cls).as_bytes()
+        r = self.build_message(message_cls=message_cls).as_bytes(linesep=RFC5321_LINESEP)
         if self._signer:
             r = self.sign_bytes(r)
         return r

--- a/emails/testsuite/message/test_dkim.py
+++ b/emails/testsuite/message/test_dkim.py
@@ -114,6 +114,8 @@ def test_dkim_as_bytes(dkim_keys):
     result = message.as_bytes()
     assert isinstance(result, bytes)
     assert b'DKIM-Signature: ' in result
+    assert b'\r\n' in result
+    assert b'\n' not in result.replace(b'\r\n', b'')
 
 
 def test_dkim_sign_after_error(dkim_keys):

--- a/emails/testsuite/message/test_send_async.py
+++ b/emails/testsuite/message/test_send_async.py
@@ -40,6 +40,9 @@ async def test_send_async_with_dict(mock_smtp):
     response = await msg.send_async(smtp={'host': 'localhost', 'port': 2525})
     assert response is not None
     assert response.success
+    sent_message = mock_smtp.data.await_args.args[0]
+    assert b'\r\n' in sent_message
+    assert b'\n' not in sent_message.replace(b'\r\n', b'')
     # Backend should have been closed (quit called)
     mock_smtp.quit.assert_awaited_once()
 


### PR DESCRIPTION
Fixes #213.

`Message.as_bytes()` now serializes messages with CRLF line endings, so sync and async SMTP delivery send RFC 5321-compliant DATA payloads.